### PR TITLE
Fix comment cleanup loop: use continue instead of return

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -154,11 +154,11 @@ ${content}
      */
     for await (const comment of existingComments.data) {
       if (comment.user?.login !== 'github-actions[bot]') {
-        return
+        continue
       }
 
       if (!comment.body?.startsWith('## Coverage difference')) {
-        return
+        continue
       }
 
       await octokit.rest.issues.deleteComment({


### PR DESCRIPTION
## Problem

The cleanup loop in `src/main.ts` that deletes previous coverage comments uses `return` instead of `continue`. This causes the entire `run()` function to exit on the first non-matching comment (e.g., a comment from a different bot), so old coverage comments are never deleted. The result is duplicate "Coverage difference" comments accumulating on pull requests with each push.

## Fix

Changed `return` to `continue` in both guard clauses of the cleanup loop so that non-matching comments are skipped and the loop continues to find and delete old coverage comments.

## Before

```typescript
for await (const comment of existingComments.data) {
  if (comment.user?.login !== 'github-actions[bot]') {
    return  // exits the entire function
  }
    return  // exits the entire function
  }
  await octokit.rest.issues.deleteComment(...)
}
```

## After

```typescript
for await (const comment of existingComments.data) {
  if (comment.user?.login !== 'github-actions[bot]') {
    continue  // skips to the next comment
  }
    continue  // skips to the next comment
  }
  await octokit.rest.issues.deleteComment(...)
}
```